### PR TITLE
fix(release): harden cross-platform MCP validation

### DIFF
--- a/.github/workflows/geochemistrypi.yml
+++ b/.github/workflows/geochemistrypi.yml
@@ -22,10 +22,10 @@ jobs:
 
     steps:
       - name: Check out repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6.0.2
 
       - name: Set up supported Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6.2.0
         with:
           python-version: "3.9"
           cache: pip
@@ -87,10 +87,10 @@ jobs:
 
     steps:
       - name: Check out repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6.0.2
 
       - name: Set up MCP Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6.2.0
         with:
           python-version: "3.11"
           cache: pip
@@ -154,10 +154,14 @@ jobs:
       - name: Install pinned setup runtime
         run: python -m pip install uv==0.11.7
 
+      - name: Install the documented macOS OpenMP runtime
+        if: runner.os == 'macOS'
+        run: brew list libomp >/dev/null 2>&1 || brew install libomp
+
       - name: Exercise clean install, repeat, repair, upgrade, rollback, and uninstall
         shell: python
         env:
-          GEOCHEMISTRYPI_MCP_APP_ROOT: ${{ runner.temp }}/geochemistrypi-mcp-lifecycle
+          GEOCHEMISTRYPI_MCP_APP_ROOT: ${{ runner.temp }}/GeochemistryPi public acceptance 用户数据
         run: |
           from pathlib import Path
           import subprocess
@@ -216,10 +220,10 @@ jobs:
 
     steps:
       - name: Check out repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6.0.2
 
       - name: Set up CLI Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6.2.0
         with:
           python-version: "3.9"
           cache: pip
@@ -233,7 +237,7 @@ jobs:
           .engine-venv/bin/python -m pip install dist/*.whl
 
       - name: Set up MCP Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6.2.0
         with:
           python-version: "3.11"
           cache: pip
@@ -249,6 +253,157 @@ jobs:
           GEOCHEMISTRYPI_MCP_APP_ROOT: ${{ runner.temp }}/geochemistrypi-mcp-parity
           SQLALCHEMY_DATABASE_URL: ""
         run: python -m pytest -m mcp_cli_parity tests/mcp_wrapper/parity
+
+  release-candidate-build:
+    name: Build reusable release candidate
+    if: github.event_name == 'workflow_dispatch'
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Set up exact CLI build Python
+        uses: actions/setup-python@v6.2.0
+        with:
+          python-version: "3.9"
+          cache: pip
+
+      - name: Build the CLI wheel once
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install build==1.3.0
+          python -m build --wheel --outdir release-candidate .
+
+      - name: Set up exact MCP build Python
+        uses: actions/setup-python@v6.2.0
+        with:
+          python-version: "3.11"
+          cache: pip
+
+      - name: Build and validate the MCP wheel and manifest
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install build==1.3.0 -e "packages/geochemistrypi-mcp[release]"
+          python -m build --wheel --outdir release-candidate packages/geochemistrypi-mcp
+          geochemistrypi-mcp-release build-manifest --dist release-candidate --source-commit "${GITHUB_SHA}"
+          geochemistrypi-mcp-release verify --bundle release-candidate --allow-unsigned
+
+      - name: Retain the one candidate used by every platform
+        uses: actions/upload-artifact@v7.0.1
+        with:
+          name: unsigned-release-candidate-${{ github.sha }}
+          path: release-candidate/
+          if-no-files-found: error
+          retention-days: 7
+
+  release-candidate-parity:
+    name: Candidate parity (${{ matrix.os }}, ${{ matrix.shard }})
+    if: github.event_name == 'workflow_dispatch'
+    needs: release-candidate-build
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 120
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, windows-latest, macos-15-intel]
+        shard: [classification-automl, regression-automl]
+
+    steps:
+      - name: Check out acceptance tests
+        uses: actions/checkout@v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Download the exact reusable candidate
+        uses: actions/download-artifact@v8.0.1
+        with:
+          name: unsigned-release-candidate-${{ github.sha }}
+          path: release-candidate
+
+      - name: Set up public installer Python
+        uses: actions/setup-python@v6.2.0
+        with:
+          python-version: "3.11"
+
+      - name: Install the pinned bootstrap tool
+        run: python -m pip install uv==0.11.7
+
+      - name: Install the documented macOS OpenMP runtime
+        if: runner.os == 'macOS'
+        run: brew list libomp >/dev/null 2>&1 || brew install libomp
+
+      - name: Install the wheel and compare the real CLI and MCP
+        shell: python
+        env:
+          GEOCHEMISTRYPI_PARITY_SHARD: ${{ matrix.shard }}
+        run: |
+          import os
+          from pathlib import Path
+          import subprocess
+
+          workspace = Path.cwd().resolve()
+          bundle = (workspace / "release-candidate").resolve()
+          mcp_wheel = next(bundle.glob("geochemistrypi_mcp-*.whl"))
+          requirement = f"geochemistrypi-mcp[release,test] @ {mcp_wheel.as_uri()}"
+          isolated = [
+              "uv", "run", "--isolated", "--no-project", "--python", "3.11",
+              "--with", requirement,
+          ]
+          app_root = Path(os.environ["RUNNER_TEMP"]) / "GeochemistryPi public acceptance 用户数据"
+          environment = os.environ.copy()
+          environment.update(
+              {
+                  "GEOCHEMISTRYPI_MCP_APP_ROOT": str(app_root),
+                  "GEOCHEMISTRYPI_FULL_PARITY": "1",
+                  "MPLBACKEND": "Agg",
+                  "SQLALCHEMY_DATABASE_URL": "",
+              }
+          )
+
+          def run(*arguments):
+              subprocess.check_call([*isolated, *arguments], env=environment)
+
+          run("geochemistrypi-mcp-release", "verify", "--bundle", str(bundle), "--allow-unsigned")
+          try:
+              run(
+                  "geochemistrypi-mcp-setup", "install", "--bundle", str(bundle),
+                  "--allow-unsigned-bundle", "--client", "standard",
+              )
+              cli_command = app_root / "environments" / "cli" / (
+                  "Scripts/geochemistrypi.exe" if os.name == "nt" else "bin/geochemistrypi"
+              )
+              if not cli_command.is_file():
+                  raise RuntimeError(f"Installed CLI command is missing: {cli_command}")
+              environment["GEOCHEMISTRYPI_CLI_EXECUTABLE"] = str(cli_command)
+              basetemp = Path(os.environ["RUNNER_TEMP"]) / f"gpf-{os.environ['GEOCHEMISTRYPI_PARITY_SHARD']}"
+              subprocess.check_call(
+                  [
+                      *isolated,
+                      "python", "-m", "pytest",
+                      "-c", str(workspace / "tests" / "installed-wheel-pytest.ini"),
+                      "--basetemp", str(basetemp),
+                      "-m", "mcp_cli_full_parity",
+                      str(workspace / "tests" / "mcp_wrapper" / "parity" / "test_full_parity_matrix.py"),
+                  ],
+                  cwd=os.environ["RUNNER_TEMP"],
+                  env=environment,
+              )
+          finally:
+              if app_root.exists():
+                  run("geochemistrypi-mcp-setup", "uninstall")
+
+      - name: Retain failed process evidence
+        if: failure()
+        uses: actions/upload-artifact@v7.0.1
+        with:
+          name: candidate-failure-${{ matrix.os }}-${{ matrix.shard }}
+          path: ${{ runner.temp }}/gpf-${{ matrix.shard }}/
+          if-no-files-found: warn
+          retention-days: 7
 
   pr9i-full-parity:
     name: PR9I full parity (${{ matrix.shard }})
@@ -269,10 +424,10 @@ jobs:
 
     steps:
       - name: Check out repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6.0.2
 
       - name: Set up CLI Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6.2.0
         with:
           python-version: "3.9"
           cache: pip
@@ -286,7 +441,7 @@ jobs:
           .engine-venv/bin/python -m pip install dist/*.whl
 
       - name: Set up MCP Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6.2.0
         with:
           python-version: "3.11"
           cache: pip

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,7 +24,7 @@ jobs:
           persist-credentials: false
 
       - name: Set up release verification Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6.2.0
         with:
           python-version: "3.11"
           cache: pip
@@ -36,7 +36,7 @@ jobs:
           python packages/geochemistrypi-mcp/tools/release_artifacts.py verify-source --repository . --release-tag "${GITHUB_REF_NAME}"
 
       - name: Set up exact CLI build Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6.2.0
         with:
           python-version: "3.9"
           cache: pip
@@ -50,7 +50,7 @@ jobs:
           python -c "from pathlib import Path; import shutil; target=Path('release-bundle'); target.mkdir(); wheels=list(Path('cli-dist').glob('*.whl')); assert len(wheels)==1, wheels; shutil.copy2(wheels[0], target / wheels[0].name)"
 
       - name: Set up exact MCP build Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6.2.0
         with:
           python-version: "3.11"
           cache: pip
@@ -105,7 +105,7 @@ jobs:
           subject-path: cli-dist/*.tar.gz
 
       - name: Retain the signed release candidate
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7.0.1
         with:
           name: geochemistrypi-${{ github.ref_name }}
           path: release-bundle/
@@ -113,14 +113,14 @@ jobs:
           retention-days: 30
 
       - name: Retain the exact CLI PyPI distributions
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7.0.1
         with:
           name: geochemistrypi-cli-${{ github.ref_name }}
           path: cli-dist/
           if-no-files-found: error
           retention-days: 30
 
-  verify-signed-release:
+  verify-signed-install:
     name: Signed install (${{ matrix.os }})
     needs: build-sign-attest
     runs-on: ${{ matrix.os }}
@@ -140,18 +140,22 @@ jobs:
           persist-credentials: false
 
       - name: Download the exact signed release candidate
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8.0.1
         with:
           name: geochemistrypi-${{ github.ref_name }}
           path: release-bundle
 
       - name: Set up the public installer runtime
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6.2.0
         with:
           python-version: "3.11"
 
       - name: Install the pinned bootstrap tool
         run: python -m pip install uv==0.11.7
+
+      - name: Install the documented macOS OpenMP runtime
+        if: runner.os == 'macOS'
+        run: brew list libomp >/dev/null 2>&1 || brew install libomp
 
       - name: Verify and install the downloaded signed bundle as a normal user
         shell: python
@@ -201,26 +205,6 @@ jobs:
           if not cli_command.is_file():
               raise SystemExit(f"Installed CLI command is missing: {cli_command}")
 
-          parity_environment = environment.copy()
-          parity_environment.update(
-              {
-                  "GEOCHEMISTRYPI_CLI_EXECUTABLE": str(cli_command),
-                  "GEOCHEMISTRYPI_FULL_PARITY": "1",
-                  "MPLBACKEND": "Agg",
-              }
-          )
-          for shard in ("classification-automl", "regression-automl"):
-              parity_environment["GEOCHEMISTRYPI_PARITY_SHARD"] = shard
-              subprocess.check_call(
-                  [
-                      *isolated,
-                      "python", "-m", "pytest",
-                      "-m", "mcp_cli_full_parity",
-                      "tests/mcp_wrapper/parity/test_full_parity_matrix.py",
-                  ],
-                  env=parity_environment,
-              )
-
           run_artifact = app_root / "runs" / "release-user-data" / "result.json"
           tracking_artifact = app_root / "tracking" / "release-user-data" / "meta.yaml"
           run_artifact.parent.mkdir(parents=True, exist_ok=True)
@@ -237,9 +221,119 @@ jobs:
           if tracking_artifact.read_text(encoding="utf-8") != "name: preserved\n":
               raise SystemExit("Uninstall changed user tracking data")
 
+  verify-signed-parity:
+    name: Signed parity (${{ matrix.os }}, ${{ matrix.shard }})
+    needs: build-sign-attest
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 120
+    strategy:
+      fail-fast: false
+      matrix:
+        # Run expensive scientific branches independently. A failure in one
+        # branch or platform must not conceal the remaining release evidence.
+        os: [ubuntu-latest, windows-latest, macos-15-intel]
+        shard: [classification-automl, regression-automl]
+
+    steps:
+      - name: Check out the tagged acceptance tests
+        uses: actions/checkout@v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Download the exact signed release candidate
+        uses: actions/download-artifact@v8.0.1
+        with:
+          name: geochemistrypi-${{ github.ref_name }}
+          path: release-bundle
+
+      - name: Set up the public installer runtime
+        uses: actions/setup-python@v6.2.0
+        with:
+          python-version: "3.11"
+
+      - name: Install the pinned bootstrap tool
+        run: python -m pip install uv==0.11.7
+
+      - name: Install the documented macOS OpenMP runtime
+        if: runner.os == 'macOS'
+        run: brew list libomp >/dev/null 2>&1 || brew install libomp
+
+      - name: Install the signed wheel and compare the real CLI and MCP
+        shell: python
+        env:
+          GEOCHEMISTRYPI_PARITY_SHARD: ${{ matrix.shard }}
+        run: |
+          import os
+          from pathlib import Path
+          import subprocess
+
+          workspace = Path.cwd().resolve()
+          bundle = (workspace / "release-bundle").resolve()
+          mcp_wheel = next(bundle.glob("geochemistrypi_mcp-*.whl"))
+          requirement = f"geochemistrypi-mcp[release,test] @ {mcp_wheel.as_uri()}"
+          isolated = [
+              "uv", "run", "--isolated", "--no-project", "--python", "3.11",
+              "--with", requirement,
+          ]
+          app_root = Path(os.environ["RUNNER_TEMP"]) / "GeochemistryPi public acceptance 用户数据"
+          environment = os.environ.copy()
+          environment.update(
+              {
+                  "GEOCHEMISTRYPI_MCP_APP_ROOT": str(app_root),
+                  "GEOCHEMISTRYPI_FULL_PARITY": "1",
+                  "MPLBACKEND": "Agg",
+                  "SQLALCHEMY_DATABASE_URL": "",
+              }
+          )
+
+          def run(*arguments):
+              subprocess.check_call([*isolated, *arguments], env=environment)
+
+          run("geochemistrypi-mcp-release", "verify", "--bundle", str(bundle))
+          try:
+              run(
+                  "geochemistrypi-mcp-setup", "install",
+                  "--bundle", str(bundle), "--client", "standard",
+              )
+              cli_command = app_root / "environments" / "cli" / (
+                  "Scripts/geochemistrypi.exe" if os.name == "nt" else "bin/geochemistrypi"
+              )
+              if not cli_command.is_file():
+                  raise RuntimeError(f"Installed CLI command is missing: {cli_command}")
+              environment["GEOCHEMISTRYPI_CLI_EXECUTABLE"] = str(cli_command)
+              basetemp = Path(os.environ["RUNNER_TEMP"]) / f"gpf-{os.environ['GEOCHEMISTRYPI_PARITY_SHARD']}"
+              subprocess.check_call(
+                  [
+                      *isolated,
+                      "python", "-m", "pytest",
+                      "-c", str(workspace / "tests" / "installed-wheel-pytest.ini"),
+                      "--basetemp", str(basetemp),
+                      "-m", "mcp_cli_full_parity",
+                      str(workspace / "tests" / "mcp_wrapper" / "parity" / "test_full_parity_matrix.py"),
+                  ],
+                  cwd=os.environ["RUNNER_TEMP"],
+                  env=environment,
+              )
+          finally:
+              if app_root.exists():
+                  subprocess.run(
+                      [*isolated, "geochemistrypi-mcp-setup", "uninstall"],
+                      env=environment,
+                      check=False,
+                  )
+
+      - name: Retain failed process evidence
+        if: failure()
+        uses: actions/upload-artifact@v7.0.1
+        with:
+          name: signed-failure-${{ matrix.os }}-${{ matrix.shard }}
+          path: ${{ runner.temp }}/gpf-${{ matrix.shard }}/
+          if-no-files-found: warn
+          retention-days: 30
+
   publish-cli-pypi:
     name: Publish CLI to PyPI
-    needs: [build-sign-attest, verify-signed-release]
+    needs: [build-sign-attest, verify-signed-install, verify-signed-parity]
     runs-on: ubuntu-latest
     environment:
       name: pypi
@@ -250,7 +344,7 @@ jobs:
 
     steps:
       - name: Download the exact verified CLI distributions
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8.0.1
         with:
           name: geochemistrypi-cli-${{ github.ref_name }}
           path: cli-dist
@@ -273,14 +367,14 @@ jobs:
 
   publish-mcp-github-release:
     name: Publish signed MCP bundle
-    needs: [build-sign-attest, verify-signed-release, publish-cli-pypi]
+    needs: [build-sign-attest, verify-signed-install, verify-signed-parity, publish-cli-pypi]
     runs-on: ubuntu-latest
     permissions:
       contents: write
 
     steps:
       - name: Download the exact verified signed bundle
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8.0.1
         with:
           name: geochemistrypi-${{ github.ref_name }}
           path: release-bundle

--- a/docs/source/For Developer/MCP/index.md
+++ b/docs/source/For Developer/MCP/index.md
@@ -156,13 +156,22 @@ preflight writes wheels, private environments, and lifecycle state to a system
 temporary directory, never to the repository or the user's real Agent
 configuration. On failure it retains that directory for diagnosis.
 
+A manually dispatched Engine baseline also builds one unsigned candidate and
+installs that exact candidate on Windows, Linux, and Intel macOS. Classification
+and regression AutoML run as independent matrix jobs, so a failure or timeout
+cannot hide the result of another platform or branch. The candidate is never
+published and accepts unsigned files only inside this pre-Tag test gate.
+
 The Tag workflow downloads the final signed artifact into clean ordinary-user
-jobs on Windows, Linux, and Intel macOS. Each job verifies the Sigstore bundles
-offline against the pinned GitHub workflow identity, installs the exact wheels
-under a path containing spaces and non-ASCII characters, runs Doctor, repairs
-the installation, runs the installed CLI through the classification and
-regression AutoML parity shards, uninstalls it, and confirms scientific
-run/tracking data was preserved. Native macOS arm64 is not claimed until that
+jobs on Windows, Linux, and Intel macOS. The lifecycle jobs verify the Sigstore
+bundles offline against the pinned GitHub workflow identity, install the exact
+wheels under a path containing spaces and non-ASCII characters, run Doctor,
+repair and uninstall the installation, and confirm scientific run/tracking data
+was preserved. Separate platform-and-shard jobs run the installed CLI through
+classification and regression AutoML before publication is unlocked. macOS
+jobs install the XGBoost prerequisite with `brew install libomp`; Doctor also
+checks the complete scientific import path so a missing native dependency is
+reported before analysis begins. Native macOS arm64 is not claimed until that
 same final-artifact gate is available and green on arm64.
 
 The CLI wheel and source distribution are built once from the clean tagged

--- a/geochemistrypi/cli.py
+++ b/geochemistrypi/cli.py
@@ -100,13 +100,16 @@ def _run_cli_pipeline(
     tracking_root: str = "",
     existing_experiment_id: str = "",
 ) -> None:
-    from .data_mining.cli_pipeline import cli_pipeline
-    from .data_mining.enum_ import DataSource
-    from .data_mining.plot.map_plot import WorldMapConfiguration
-
-    parsed_world_map_config = WorldMapConfiguration.from_json(world_map_config) if world_map_config else None
-
     def execute() -> None:
+        # Keep scientific imports inside the automation boundary.  If a native
+        # dependency is missing or incompatible, the CLI now emits a structured
+        # failure document instead of leaving the MCP driver with only a missing
+        # events-file symptom.
+        from .data_mining.cli_pipeline import cli_pipeline
+        from .data_mining.enum_ import DataSource
+        from .data_mining.plot.map_plot import WorldMapConfiguration
+
+        parsed_world_map_config = WorldMapConfiguration.from_json(world_map_config) if world_map_config else None
         cli_pipeline(
             training_data_path=training_data_path,
             application_data_path=application_data_path,

--- a/geochemistrypi/data_mining/model/_base.py
+++ b/geochemistrypi/data_mining/model/_base.py
@@ -84,6 +84,19 @@ class WorkflowBase(metaclass=ABCMeta):
             value = value[0]
         return int(value)
 
+    def _automl_mlp_configurations(self) -> List[Dict[str, int]]:
+        """Generate a fixed-size, serial MLP search without worker processes."""
+        generator = np.random.RandomState(self._automl_random_seed())
+        return [
+            {
+                "l1": int(generator.randint(1, 20)),
+                "l2": int(generator.randint(1, 30)),
+                "l3": int(generator.randint(1, 20)),
+                "batch": int(generator.randint(20, 100)),
+            }
+            for _ in range(self.automl_tuning_trials)
+        ]
+
     @property
     def image_config(self):
         return {

--- a/geochemistrypi/data_mining/model/classification.py
+++ b/geochemistrypi/data_mining/model/classification.py
@@ -2494,12 +2494,8 @@ class MLPClassification(ClassificationWorkflowBase):
         self.naming = MLPClassification.name
 
     def ray_tune(self, X_train: pd.DataFrame, X_test: pd.DataFrame, y_train: pd.DataFrame, y_test: pd.DataFrame) -> None:
-        """The customized MLP of the combinations of Ray, FLAML and Scikit-learn framework."""
+        """Select a deterministic MLP configuration in the current process."""
 
-        from ray import tune
-        from ray.air import session
-        from ray.tune.search import ConcurrencyLimiter
-        from ray.tune.search.flaml import BlendSearch
         from sklearn.metrics import accuracy_score
 
         random_state = self._automl_random_seed()
@@ -2508,49 +2504,15 @@ class MLPClassification(ClassificationWorkflowBase):
             """The customized model by Scikit-learn framework."""
             return MLPClassifier(hidden_layer_sizes=(l1, l2, l3), batch_size=batch, random_state=random_state)
 
-        def evaluate(l1: int, l2: int, l3: int, batch: int) -> float:
-            """The evaluation function by simulating a long-running ML experiment
-            to get the model's performance at every epoch."""
-            clfr = customized_model(l1, l2, l3, batch)
+        scored_models = []
+        for config in self._automl_mlp_configurations():
+            clfr = customized_model(**config)
             clfr.fit(X_train, y_train)
             y_pred = clfr.predict(X_test)
-            acc = accuracy_score(y_test, y_pred)
-            return acc
+            scored_models.append((float(accuracy_score(y_test, y_pred)), config))
 
-        def objective(config: Dict) -> None:
-            """Evaluate one deterministic MLP configuration and report its accuracy."""
-            score = evaluate(config["l1"], config["l2"], config["l3"], config["batch"])
-            session.report({"score": score})
-
-        # Search space: The critical assumption is that the optimal hyper-parameters live within this space.
-        search_config = {
-            "l1": tune.randint(1, 20),
-            "l2": tune.randint(1, 30),
-            "l3": tune.randint(1, 20),
-            "batch": tune.randint(20, 100),
-        }
-
-        # A seeded, fixed-size, serial search is reproducible across direct CLI
-        # and MCP-launched processes. Accuracy must be maximized, not minimized.
-        algo = BlendSearch(metric="score", mode="max", space=search_config, seed=random_state)
-        algo = ConcurrencyLimiter(algo, max_concurrent=1)
-
-        # Search the configured number of candidate networks and maximize accuracy.
-        tuner = tune.Tuner(
-            objective,
-            tune_config=tune.TuneConfig(
-                metric="score",
-                mode="max",
-                search_alg=algo,
-                num_samples=self.automl_tuning_trials,
-            ),
-            param_space={},
-        )
-        results = tuner.fit()
-
-        # The hyper-parameters found to maximize accuracy and the corresponding model.
-        best_result = results.get_best_result(metric="score", mode="max")
-        self.ray_best_model = customized_model(best_result.config["l1"], best_result.config["l2"], best_result.config["l3"], best_result.config["batch"])
+        _, best_config = max(scored_models, key=lambda item: item[0])
+        self.ray_best_model = customized_model(**best_config)
 
     @classmethod
     def manual_hyper_parameters(cls) -> Dict:

--- a/geochemistrypi/data_mining/model/regression.py
+++ b/geochemistrypi/data_mining/model/regression.py
@@ -2044,12 +2044,8 @@ class MLPRegression(RegressionWorkflowBase):
         self.naming = MLPRegression.name
 
     def ray_tune(self, X_train: pd.DataFrame, X_test: pd.DataFrame, y_train: pd.DataFrame, y_test: pd.DataFrame) -> None:
-        """The customized MLP of the combinations of Ray, FLAML and Scikit-learn framework."""
+        """Select a deterministic MLP configuration in the current process."""
 
-        from ray import tune
-        from ray.air import session
-        from ray.tune.search import ConcurrencyLimiter
-        from ray.tune.search.flaml import BlendSearch
         from sklearn.metrics import mean_squared_error
 
         random_state = self._automl_random_seed()
@@ -2058,51 +2054,16 @@ class MLPRegression(RegressionWorkflowBase):
             """The customized model by Scikit-learn framework."""
             return MLPRegressor(hidden_layer_sizes=(l1, l2, l3), batch_size=batch, random_state=random_state)
 
-        def evaluate(l1: int, l2: int, l3: int, batch: int) -> float:
-            """The evaluation function by simulating a long-running ML experiment
-            to get the model's performance at every epoch."""
-            regr = customized_model(l1, l2, l3, batch)
+        scored_models = []
+        for config in self._automl_mlp_configurations():
+            regr = customized_model(**config)
             regr.fit(X_train, y_train)
             y_pred = regr.predict(X_test)
             mse = mean_squared_error(y_test, y_pred)
-            rmse = np.sqrt(mse)  # Use RMSE score
-            return rmse
+            scored_models.append((float(np.sqrt(mse)), config))
 
-        def objective(config: Dict) -> None:
-            """Evaluate one deterministic MLP configuration and report its RMSE."""
-            score = evaluate(config["l1"], config["l2"], config["l3"], config["batch"])
-            session.report({"mean_loss": score})
-
-        # Search space: The critical assumption is that the optimal hyper-parameters live within this space.
-        search_config = {
-            "l1": tune.randint(1, 20),
-            "l2": tune.randint(1, 30),
-            "l3": tune.randint(1, 20),
-            "batch": tune.randint(20, 100),
-        }
-
-        # Use a seeded, fixed-size, serial search so repeated scientific runs
-        # evaluate the same configurations in the same order.
-        algo = BlendSearch(metric="mean_loss", mode="min", space=search_config, seed=random_state)
-        algo = ConcurrencyLimiter(algo, max_concurrent=1)
-
-        # Use Ray Tune to  run the experiment to "min"imize the “mean_loss” of the "objective"
-        # by searching "search_config" via "algo", "num_samples" times.
-        tuner = tune.Tuner(
-            objective,
-            tune_config=tune.TuneConfig(
-                metric="mean_loss",
-                mode="min",
-                search_alg=algo,
-                num_samples=self.automl_tuning_trials,
-            ),
-            param_space={},
-        )
-        results = tuner.fit()
-
-        # The hyper-parameters found to minimize the mean loss of the defined objective and the corresponding model.
-        best_result = results.get_best_result(metric="mean_loss", mode="min")
-        self.ray_best_model = customized_model(best_result.config["l1"], best_result.config["l2"], best_result.config["l3"], best_result.config["batch"])
+        _, best_config = min(scored_models, key=lambda item: item[0])
+        self.ray_best_model = customized_model(**best_config)
 
     @classmethod
     def manual_hyper_parameters(cls) -> Dict:

--- a/geochemistrypi/data_mining/tests/test_cli_automation.py
+++ b/geochemistrypi/data_mining/tests/test_cli_automation.py
@@ -121,6 +121,39 @@ def test_automation_plan_supports_noninteractive_commands(tmp_path: Path) -> Non
     assert events["events"] == []
 
 
+def test_scientific_import_failures_are_recorded_by_the_automation_contract(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    plan_path = tmp_path / "plan.json"
+    events_path = tmp_path / "events.json"
+    _write_plan(plan_path, [])
+    original_import = builtins.__import__
+
+    def failing_import(name, *args, **kwargs):
+        if name.endswith("data_mining.cli_pipeline"):
+            raise RuntimeError("native scientific dependency is unavailable")
+        return original_import(name, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, "__import__", failing_import)
+
+    with pytest.raises(RuntimeError, match="native scientific dependency is unavailable"):
+        cli_module._run_cli_pipeline(
+            training_data_path="unused.csv",
+            application_data_path="",
+            data_source_name="DATA",
+            automation_plan=str(plan_path.resolve()),
+            automation_events=str(events_path.resolve()),
+        )
+
+    events = json.loads(events_path.read_text(encoding="utf-8"))
+    assert events["status"] == "failed"
+    assert events["error"] == {
+        "type": "RuntimeError",
+        "message": "native scientific dependency is unavailable",
+    }
+
+
 def test_data_mining_tracking_options_require_safe_stable_selection(tmp_path: Path, monkeypatch) -> None:
     runner = CliRunner()
     missing_root = runner.invoke(

--- a/geochemistrypi/data_mining/tests/test_multiclass_regressions.py
+++ b/geochemistrypi/data_mining/tests/test_multiclass_regressions.py
@@ -405,23 +405,18 @@ def test_regression_cross_validation_scores_remain_numeric_in_json_output() -> N
     assert all(isinstance(value, float) for value in result["Fold Scores"])
 
 
-@pytest.mark.parametrize(
-    ("tuning_method", "metric", "mode"),
-    [
-        (MLPClassification.ray_tune, "score", "max"),
-        (MLPRegression.ray_tune, "mean_loss", "min"),
-    ],
-)
-def test_mlp_automl_uses_seeded_fixed_serial_trials(tuning_method, metric: str, mode: str) -> None:
-    source = inspect.getsource(tuning_method)
+@pytest.mark.parametrize("workflow", [MLPClassification(), MLPRegression()])
+def test_mlp_automl_uses_seeded_fixed_in_process_trials(workflow) -> None:
+    first = workflow._automl_mlp_configurations()
+    second = workflow._automl_mlp_configurations()
 
-    assert "time_budget_s" not in source
-    assert "max_concurrent=1" in source
-    assert "num_samples=self.automl_tuning_trials" in source
-    assert f'metric="{metric}"' in source
-    assert f'mode="{mode}"' in source
-    assert "seed=random_state" in source
-    assert "random_state=random_state" in source
+    assert first == second
+    assert len(first) == workflow.automl_tuning_trials
+    assert all(1 <= config["l1"] < 20 for config in first)
+    assert all(1 <= config["l2"] < 30 for config in first)
+    assert all(1 <= config["l3"] < 20 for config in first)
+    assert all(20 <= config["batch"] < 100 for config in first)
+    assert "from ray" not in inspect.getsource(workflow.ray_tune)
 
 
 @pytest.mark.parametrize(

--- a/packages/geochemistrypi-mcp/README.md
+++ b/packages/geochemistrypi-mcp/README.md
@@ -64,6 +64,11 @@ wheel, packaged repository tests, a size or SHA-256 mismatch, an untrusted
 workflow identity, or a missing signature before changing the installed
 runtime.
 
+On macOS, GeochemistryPi's XGBoost runtime requires the system OpenMP library.
+Install it once with `brew install libomp` before setup. The installer Doctor
+checks the complete scientific import path and reports this prerequisite
+directly if it is missing; Windows and Linux require no equivalent step.
+
 The intended scientist-facing installation is natural language. Download and
 extract the signed release bundle, then give its folder to any supported Agent:
 
@@ -182,10 +187,11 @@ On macOS or Linux:
 ~/.local/state/geochemistrypi-mcp/environments/mcp/bin/geochemistrypi-mcp-doctor
 ```
 
-The doctor performs nine checks: persisted paths and all six resource limits;
+The doctor performs ten checks: persisted paths and all six resource limits;
 the exact CLI/MCP compatibility manifest; release-manifest and wheel hashes;
 both installed distribution-inventory hashes; writable managed storage; exact
-private Python/package versions; the public CLI command; zero-argument MCP
+private Python/package versions; the public CLI command; the complete
+scientific CLI import path (including native dependencies); zero-argument MCP
 startup; and the 13 expected tools. It also rejects a claimed rollback whose
 private snapshot is missing. Add `--json` for machine-readable output.
 

--- a/packages/geochemistrypi-mcp/src/geochemistrypi_mcp/lifecycle/console.py
+++ b/packages/geochemistrypi-mcp/src/geochemistrypi_mcp/lifecycle/console.py
@@ -1,0 +1,30 @@
+"""Encoding-safe output for human-facing lifecycle commands.
+
+The MCP server itself must keep stdout reserved for JSON-RPC.  This module is
+therefore used only by the setup, doctor, and release administration entry
+points, where paths supplied by scientists may contain any Unicode character.
+"""
+
+from __future__ import annotations
+
+import sys
+from typing import TextIO
+
+
+def _configure_stream(stream: TextIO) -> None:
+    """Prefer UTF-8 and a non-crashing fallback on reconfigurable streams."""
+    reconfigure = getattr(stream, "reconfigure", None)
+    if reconfigure is None:
+        return
+    try:
+        reconfigure(encoding="utf-8", errors="backslashreplace")
+    except (AttributeError, OSError, ValueError):
+        # Test captures and embedding hosts can expose immutable text streams.
+        # Their own write policy remains in force.
+        return
+
+
+def configure_utf8_console() -> None:
+    """Make administrative output safe for Unicode paths on every platform."""
+    _configure_stream(sys.stdout)
+    _configure_stream(sys.stderr)

--- a/packages/geochemistrypi-mcp/src/geochemistrypi_mcp/lifecycle/doctor.py
+++ b/packages/geochemistrypi-mcp/src/geochemistrypi_mcp/lifecycle/doctor.py
@@ -18,6 +18,7 @@ from mcp.client.stdio import stdio_client
 
 from ..config.constants import CLI_PYTHON_REQUIRES, COMPATIBILITY_POLICY_VERSION, ISOLATED_CLI_ENVIRONMENT_VARIABLES, MCP_PYTHON_REQUIRES, MCP_SDK_REQUIRES, SERVER_VERSION, SUPPORTED_CLI_VERSIONS
 from ..config.settings import SETTINGS_FILE_ENV, SETTINGS_SCHEMA_VERSION, resolve_cli_interpreter
+from .console import configure_utf8_console
 from .release import SIGSTORE_BUNDLE_SUFFIX, ReleaseError, verify_release_bundle
 from .setup import MANIFEST_SCHEMA_VERSION, SetupPaths
 
@@ -376,6 +377,12 @@ def _validate_cli_runtime(output: str) -> str:
     return f"Python {value['python']}; geochemistrypi {package_version}."
 
 
+def _validate_cli_scientific_runtime(output: str) -> str:
+    if output != "scientific-runtime-ready":
+        raise ValueError("CLI scientific runtime returned an invalid import handshake.")
+    return "Scientific CLI modules and their native dependencies import successfully."
+
+
 async def _probe_protocol(paths: SetupPaths) -> tuple[bool, str]:
     parameters = StdioServerParameters(
         command=str(paths.server_command),
@@ -442,6 +449,18 @@ def run_doctor(
                 _validate_cli_runtime,
             )
         )
+        checks.append(
+            _command_result(
+                runner,
+                (
+                    str(cli_python),
+                    "-c",
+                    "import geochemistrypi.data_mining.cli_pipeline; " "print('scientific-runtime-ready')",
+                ),
+                "cli-scientific-runtime",
+                _validate_cli_scientific_runtime,
+            )
+        )
     checks.append(
         _command_result(
             runner,
@@ -466,6 +485,7 @@ def _parser() -> argparse.ArgumentParser:
 
 def main(argv: Sequence[str] | None = None) -> None:
     """Run diagnostics without ever writing protocol data to stdout."""
+    configure_utf8_console()
     arguments = _parser().parse_args(argv)
     report = run_doctor()
     if arguments.json:

--- a/packages/geochemistrypi-mcp/src/geochemistrypi_mcp/lifecycle/release.py
+++ b/packages/geochemistrypi-mcp/src/geochemistrypi_mcp/lifecycle/release.py
@@ -18,6 +18,7 @@ from typing import Callable, Mapping, Sequence
 from zipfile import BadZipFile, ZipFile
 
 from ..config.constants import CLI_PYTHON_REQUIRES, CLI_VERSION, MCP_PYTHON_REQUIRES, MCP_SDK_REQUIRES, PENDING_RELEASE_GATES, PUBLIC_RELEASE_READY, RELEASE_CHANNEL, SERVER_VERSION
+from .console import configure_utf8_console
 
 RELEASE_MANIFEST_SCHEMA_VERSION = 2
 RELEASE_MANIFEST_FILENAME = "release-manifest.json"
@@ -490,6 +491,7 @@ def _parser() -> argparse.ArgumentParser:
 
 
 def main(argv: Sequence[str] | None = None) -> None:
+    configure_utf8_console()
     arguments = _parser().parse_args(argv)
     try:
         if arguments.action == "build-manifest":

--- a/packages/geochemistrypi-mcp/src/geochemistrypi_mcp/lifecycle/setup.py
+++ b/packages/geochemistrypi-mcp/src/geochemistrypi_mcp/lifecycle/setup.py
@@ -30,6 +30,7 @@ from ..config.settings import (
     SettingsError,
     default_app_root,
 )
+from .console import configure_utf8_console
 from .release import ReleaseBundle, ReleaseError, verify_release_bundle
 
 MCP_PYTHON_VERSION = "3.11"
@@ -1077,6 +1078,7 @@ def _windows_external_bootstrap_guidance(
 
 def main(argv: Sequence[str] | None = None) -> None:
     """Run the administrative lifecycle command without starting MCP stdio."""
+    configure_utf8_console()
     raw_arguments = tuple(argv) if argv is not None else tuple(sys.argv[1:])
     arguments = _parser().parse_args(raw_arguments)
     try:

--- a/packages/geochemistrypi-mcp/src/geochemistrypi_mcp/runtime/cli_driver.py
+++ b/packages/geochemistrypi-mcp/src/geochemistrypi_mcp/runtime/cli_driver.py
@@ -44,6 +44,19 @@ def _normalize_console_output(value: str) -> str:
     return ANSI_ESCAPE.sub("", value).replace("\r", "").replace("\f", "\n")
 
 
+def _diagnostic_tail(parts: List[str], limit: int = 2000) -> str:
+    """Return a bounded single-line process diagnostic suitable for an error."""
+    normalized = " ".join(_normalize_console_output("".join(parts)).split())
+    if len(normalized) > limit:
+        return "..." + normalized[-limit:]
+    return normalized
+
+
+def _process_failure_message(prefix: str, stderr_parts: List[str], stdout_parts: List[str]) -> str:
+    diagnostic = _diagnostic_tail(stderr_parts) or _diagnostic_tail(stdout_parts)
+    return f"{prefix} Process diagnostic: {diagnostic}" if diagnostic else prefix
+
+
 def _write_text_atomically(path: Path, value: str) -> None:
     """Publish a complete capture file without exposing a partial write."""
     with tempfile.NamedTemporaryFile("w", encoding="utf-8", dir=path.parent, prefix=f".{path.name}.", suffix=".tmp", delete=False) as stream:
@@ -437,7 +450,14 @@ class CliInteractionDriver:
                 if cancellation_event is not None and cancellation_event.is_set():
                     raise CliRunCancelledError("The run was cancelled by request.", workspace_path)
                 if now - started_monotonic > self.process_timeout_seconds:
-                    raise PromptTimeoutError(f"CLI process exceeded the {self.process_timeout_seconds:g}-second total timeout.", workspace_path)
+                    raise PromptTimeoutError(
+                        _process_failure_message(
+                            f"CLI process exceeded the {self.process_timeout_seconds:g}-second total timeout.",
+                            stderr_parts,
+                            stdout_parts,
+                        ),
+                        workspace_path,
+                    )
                 if not self.automation_mode and step_index < len(plan.steps):
                     expected = plan.steps[step_index]
                     prompt_timeout = expected.timeout_seconds or self.prompt_timeout_seconds
@@ -497,13 +517,35 @@ class CliInteractionDriver:
 
             returncode = process.wait()
             if self.automation_mode:
-                completed_step_ids, interaction_events = _load_automation_events(automation_events_path, plan, workspace_path)
+                if automation_events_path.is_file():
+                    completed_step_ids, interaction_events = _load_automation_events(automation_events_path, plan, workspace_path)
+                elif returncode != 0:
+                    raise CliProcessError(
+                        _process_failure_message(
+                            f"CLI exited with code {returncode} before producing automation events.",
+                            stderr_parts,
+                            stdout_parts,
+                        ),
+                        workspace_path,
+                    )
+                else:
+                    raise CliProcessError(
+                        "CLI exited successfully without producing automation events.",
+                        workspace_path,
+                    )
                 step_index = len(completed_step_ids)
             elif step_index != len(plan.steps):
                 unused = [step.id for step in plan.steps[step_index:]]
                 raise UnusedResponsesError(f"CLI exited with code {returncode} before consuming {len(unused)} planned responses: {unused}", workspace_path)
             if returncode != 0:
-                raise CliProcessError(f"CLI consumed the interaction plan but exited with code {returncode}.", workspace_path)
+                raise CliProcessError(
+                    _process_failure_message(
+                        f"CLI consumed the interaction plan but exited with code {returncode}.",
+                        stderr_parts,
+                        stdout_parts,
+                    ),
+                    workspace_path,
+                )
         except BaseException as exc:
             error = exc
             if process is not None:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,8 +30,6 @@ classifiers = [
 
 dependencies = [
     "typer==0.7.0",
-    "ray==2.2.0",
-    "ray[tune]",
     "optuna==3.1.1",
     "pydantic<2.0.0",
     "scikit-learn==1.1.3",

--- a/requirements/development.txt
+++ b/requirements/development.txt
@@ -1,6 +1,4 @@
 typer==0.7.0
-ray==2.6.0
-ray[tune]
 optuna
 pydantic<2.0.0
 scikit-learn<1.4

--- a/requirements/production.txt
+++ b/requirements/production.txt
@@ -1,6 +1,4 @@
 typer==0.7.0
-ray==2.2.0
-ray[tune]
 optuna==3.1.1
 pydantic<2.0.0
 scikit-learn==1.1.3

--- a/tests/cli_contract/fixtures/classification_golden_v1.json
+++ b/tests/cli_contract/fixtures/classification_golden_v1.json
@@ -21,7 +21,7 @@
     "openpyxl": "3.0.10"
   },
   "cli_entry_files": {
-    "geochemistrypi/cli.py": "d2fc0e802f6951b6a22e5304b6c760f601bb047ad39a5f6fca739f3686bbeca9",
+    "geochemistrypi/cli.py": "9e98bdda3bf3da085d851f7ccb581dab981315cdb20706cc2a7959ec5df4c36b",
     "geochemistrypi/data_mining/cli_pipeline.py": "089680b189048038bdd89e033e5683e4e9894f9b01f2dca5388542a88c39e894"
   },
   "model": {

--- a/tests/mcp_wrapper/installation/test_console.py
+++ b/tests/mcp_wrapper/installation/test_console.py
@@ -15,6 +15,4 @@ def test_lifecycle_console_handles_unicode_paths_under_a_legacy_code_page(
     print("D:/GeochemistryPi/用户数据")
     legacy_stdout.flush()
 
-    assert raw.getvalue().decode("utf-8").splitlines() == [
-        "D:/GeochemistryPi/用户数据"
-    ]
+    assert raw.getvalue().decode("utf-8").splitlines() == ["D:/GeochemistryPi/用户数据"]

--- a/tests/mcp_wrapper/installation/test_console.py
+++ b/tests/mcp_wrapper/installation/test_console.py
@@ -1,0 +1,20 @@
+import io
+import sys
+
+from geochemistrypi_mcp.lifecycle.console import configure_utf8_console
+
+
+def test_lifecycle_console_handles_unicode_paths_under_a_legacy_code_page(
+    monkeypatch,
+) -> None:
+    raw = io.BytesIO()
+    legacy_stdout = io.TextIOWrapper(raw, encoding="cp1252", errors="strict")
+    monkeypatch.setattr(sys, "stdout", legacy_stdout)
+
+    configure_utf8_console()
+    print("D:/GeochemistryPi/用户数据")
+    legacy_stdout.flush()
+
+    assert raw.getvalue().decode("utf-8").splitlines() == [
+        "D:/GeochemistryPi/用户数据"
+    ]

--- a/tests/mcp_wrapper/installation/test_doctor.py
+++ b/tests/mcp_wrapper/installation/test_doctor.py
@@ -82,6 +82,8 @@ def test_doctor_checks_both_runtimes_storage_and_real_protocol_boundary(tmp_path
         command = tuple(command)
         if command[-1] == "--version":
             return subprocess.CompletedProcess(command, 0, f"Geochemistry Pi {CLI_VERSION}\n", "")
+        if "scientific-runtime-ready" in command[-1]:
+            return subprocess.CompletedProcess(command, 0, "scientific-runtime-ready\n", "")
         package = "geochemistrypi-mcp" if str(paths.mcp_python) == command[0] else "geochemistrypi"
         python = [3, 11, 9] if package == "geochemistrypi-mcp" else [3, 9, 19]
         return subprocess.CompletedProcess(
@@ -99,7 +101,7 @@ def test_doctor_checks_both_runtimes_storage_and_real_protocol_boundary(tmp_path
     )
 
     assert report.healthy is True
-    assert report.summary == "Doctor: healthy (9/9 checks passed)."
+    assert report.summary == "Doctor: healthy (10/10 checks passed)."
     assert {check.name for check in report.checks} == {
         "settings",
         "install-manifest",
@@ -108,6 +110,7 @@ def test_doctor_checks_both_runtimes_storage_and_real_protocol_boundary(tmp_path
         "managed-storage",
         "mcp-runtime",
         "cli-runtime",
+        "cli-scientific-runtime",
         "cli-command",
         "mcp-protocol",
     }
@@ -120,6 +123,8 @@ def test_doctor_reports_version_and_protocol_failures_without_crashing(tmp_path:
         command = tuple(command)
         if command[-1] == "--version":
             return subprocess.CompletedProcess(command, 0, "Geochemistry Pi 0.7.0\n", "")
+        if "scientific-runtime-ready" in command[-1]:
+            return subprocess.CompletedProcess(command, 1, "", "libomp is unavailable")
         package = "geochemistrypi-mcp" if str(paths.mcp_python) == command[0] else "geochemistrypi"
         return subprocess.CompletedProcess(
             command,
@@ -139,6 +144,7 @@ def test_doctor_reports_version_and_protocol_failures_without_crashing(tmp_path:
     failed = {check.name: check.detail for check in report.checks if not check.healthy}
     assert "does not match" in failed["mcp-runtime"]
     assert "must use Python 3.9" in failed["cli-runtime"]
+    assert failed["cli-scientific-runtime"] == "libomp is unavailable"
     assert failed["mcp-protocol"] == "server did not initialize"
 
 

--- a/tests/mcp_wrapper/installation/test_release.py
+++ b/tests/mcp_wrapper/installation/test_release.py
@@ -91,17 +91,28 @@ def test_release_version_has_one_canonical_package_value() -> None:
 def test_release_workflow_installs_the_signed_artifact_on_every_supported_os() -> None:
     release_workflow = (REPOSITORY_ROOT / ".github" / "workflows" / "release.yml").read_text(encoding="utf-8")
     engine_workflow = (REPOSITORY_ROOT / ".github" / "workflows" / "geochemistrypi.yml").read_text(encoding="utf-8")
-    signed_job = release_workflow.split("  verify-signed-release:", maxsplit=1)[1]
+    signed_install = release_workflow.split("  verify-signed-install:", maxsplit=1)[1].split("  verify-signed-parity:", maxsplit=1)[0]
+    signed_parity = release_workflow.split("  verify-signed-parity:", maxsplit=1)[1].split("  publish-cli-pypi:", maxsplit=1)[0]
 
-    assert "os: [ubuntu-latest, windows-latest, macos-15-intel]" in signed_job
-    assert "uses: actions/download-artifact@v4" in signed_job
-    assert 'run("geochemistrypi-mcp-release", "verify", "--bundle", str(bundle))' in signed_job
-    assert '"geochemistrypi-mcp-setup", "install"' in signed_job
-    assert 'run("geochemistrypi-mcp-doctor", "--json")' in signed_job
-    assert 'run("geochemistrypi-mcp-setup", "uninstall")' in signed_job
-    assert 'for shard in ("classification-automl", "regression-automl")' in signed_job
-    assert '"-m", "mcp_cli_full_parity"' in signed_job
-    assert "--allow-unsigned" not in signed_job
+    assert "os: [ubuntu-latest, windows-latest, macos-15-intel]" in signed_install
+    assert "uses: actions/download-artifact@v8.0.1" in signed_install
+    assert 'run("geochemistrypi-mcp-release", "verify", "--bundle", str(bundle))' in signed_install
+    assert '"geochemistrypi-mcp-setup", "install"' in signed_install
+    assert 'run("geochemistrypi-mcp-doctor", "--json")' in signed_install
+    assert 'run("geochemistrypi-mcp-setup", "uninstall")' in signed_install
+    assert "--allow-unsigned" not in signed_install
+
+    assert "os: [ubuntu-latest, windows-latest, macos-15-intel]" in signed_parity
+    assert "shard: [classification-automl, regression-automl]" in signed_parity
+    assert '"-m", "mcp_cli_full_parity"' in signed_parity
+    assert '"-c", str(workspace / "tests" / "installed-wheel-pytest.ini")' in signed_parity
+    assert 'cwd=os.environ["RUNNER_TEMP"]' in signed_parity
+    assert "--allow-unsigned" not in signed_parity
+
+    assert "release-candidate-build:" in engine_workflow
+    assert "release-candidate-parity:" in engine_workflow
+    assert "shard: [classification-automl, regression-automl]" in engine_workflow
+    assert "GeochemistryPi public acceptance 用户数据" in engine_workflow
     assert "--release-tag mcp-v" not in engine_workflow
 
 
@@ -113,9 +124,18 @@ def test_release_workflow_builds_once_and_publishes_only_after_final_gates() -> 
     assert release_workflow.count("python -m build --sdist --wheel --outdir cli-dist .") == 1
     assert "verify-artifacts" in release_workflow
     assert "pypa/gh-action-pypi-publish@release/v1" in release_workflow
-    assert "needs: [build-sign-attest, verify-signed-release]" in release_workflow
-    assert "needs: [build-sign-attest, verify-signed-release, publish-cli-pypi]" in release_workflow
+    assert "needs: [build-sign-attest, verify-signed-install, verify-signed-parity]" in release_workflow
+    assert "needs: [build-sign-attest, verify-signed-install, verify-signed-parity, publish-cli-pypi]" in release_workflow
     assert 'gh release create "${GITHUB_REF_NAME}"' in release_workflow
+
+
+def test_workflows_use_node24_action_generations() -> None:
+    workflows = "\n".join(path.read_text(encoding="utf-8") for path in (REPOSITORY_ROOT / ".github" / "workflows").glob("*.yml"))
+
+    assert "actions/checkout@v4" not in workflows
+    assert "actions/setup-python@v5" not in workflows
+    assert "actions/upload-artifact@v4" not in workflows
+    assert "actions/download-artifact@v4" not in workflows
 
 
 def test_release_bundle_verifies_every_sigstore_identity_and_rejects_tampering(

--- a/tests/mcp_wrapper/interaction/test_driver_unit.py
+++ b/tests/mcp_wrapper/interaction/test_driver_unit.py
@@ -10,6 +10,7 @@ from geochemistrypi_mcp import (
     ClassificationPlanCompiler,
     ClassificationRequest,
     CliInteractionDriver,
+    CliProcessError,
     InteractionPlan,
     InteractionStep,
     PlanCompilationError,
@@ -380,6 +381,26 @@ print('automation completed', flush=True)
     assert trace["events"][0]["response"] == "alpha"
     assert "--automation-plan" in trace["command"]
     assert "OLD FIRST PROMPT" not in result.stdout_path.read_text(encoding="utf-8")
+
+
+def test_driver_surfaces_process_diagnostic_when_automation_never_starts(
+    tmp_path: Path,
+) -> None:
+    script = _fake_script(
+        tmp_path,
+        "import sys\nprint('native dependency could not be loaded', file=sys.stderr)\nraise SystemExit(17)\n",
+    )
+
+    with pytest.raises(
+        CliProcessError,
+        match="exited with code 17 before producing automation events.*native dependency could not be loaded",
+    ) as captured:
+        CliInteractionDriver(process_timeout_seconds=10, automation_mode=True).run(
+            _plan(script, ()),
+            workspace_parent=tmp_path / "runs",
+        )
+
+    assert "native dependency could not be loaded" in (captured.value.capture_directory / "stderr.log").read_text(encoding="utf-8")
 
 
 def test_driver_fails_on_a_known_prompt_arriving_out_of_order(tmp_path: Path) -> None:

--- a/uv.lock
+++ b/uv.lock
@@ -9,19 +9,6 @@ resolution-markers = [
 ]
 
 [[package]]
-name = "aiosignal"
-version = "1.4.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "frozenlist" },
-    { name = "typing-extensions" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/61/62/06741b579156360248d1ec624842ad0edf697050bbaf7c3e46394e106ad1/aiosignal-1.4.0.tar.gz", hash = "sha256:f47eecd9468083c2029cc99945502cb7708b082c232f9aca65da147157b251c7", size = 25007, upload-time = "2025-07-03T22:54:43.528Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/fb/76/641ae371508676492379f16e2fa48f4e2c11741bd63c48be4b12a6b09cba/aiosignal-1.4.0-py3-none-any.whl", hash = "sha256:053243f8b92b990551949e63930a839ff0cf0b0ebbe0597b0f3fb19e1a0fe82e", size = 7490, upload-time = "2025-07-03T22:54:42.156Z" },
-]
-
-[[package]]
 name = "alembic"
 version = "1.16.5"
 source = { registry = "https://pypi.org/simple" }
@@ -48,15 +35,6 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/96/f0/5eb65b2bb0d09ac6776f2eb54adee6abe8228ea05b20a5ad0e4945de8aac/anyio-4.12.1.tar.gz", hash = "sha256:41cfcc3a4c85d3f05c932da7c26d0201ac36f72abd4435ba90d0464a3ffed703", size = 228685, upload-time = "2026-01-06T11:45:21.246Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/38/0e/27be9fdef66e72d64c0cdc3cc2823101b80585f8119b5c112c2e8f5f7dab/anyio-4.12.1-py3-none-any.whl", hash = "sha256:d405828884fc140aa80a3c667b8beed277f1dfedec42ba031bd6ac3db606ab6c", size = 113592, upload-time = "2026-01-06T11:45:19.497Z" },
-]
-
-[[package]]
-name = "attrs"
-version = "26.1.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/9a/8e/82a0fe20a541c03148528be8cac2408564a6c9a0cc7e9171802bc1d26985/attrs-26.1.0.tar.gz", hash = "sha256:d03ceb89cb322a8fd706d4fb91940737b6642aa36998fe130a9bc96c985eff32", size = 952055, upload-time = "2026-03-19T14:22:25.026Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/64/b4/17d4b0b2a2dc85a6df63d1157e028ed19f90d4cd97c36717afef2bc2f395/attrs-26.1.0-py3-none-any.whl", hash = "sha256:c647aa4a12dfbad9333ca4e71fe62ddc36f4e63b2d260a37a8b83d2f043ac309", size = 67548, upload-time = "2026-03-19T14:22:23.645Z" },
 ]
 
 [[package]]
@@ -393,15 +371,6 @@ wheels = [
 ]
 
 [[package]]
-name = "distlib"
-version = "0.4.3"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/c9/02/bd72be9134d25ed783ecbbc38a539ffaefbf90c78418c7fb7229600dbac7/distlib-0.4.3.tar.gz", hash = "sha256:f152097224a0ae24be5a0f6bae1b9359af82133bce63f98a95f86cae1aede9ed", size = 615141, upload-time = "2026-06-12T08:04:52.847Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/02/08/9c41fb51ab5b43eb21674aff13df270e8ba6c4b29c8624e328dc7a9482af/distlib-0.4.3-py2.py3-none-any.whl", hash = "sha256:4b0ce306c966eb73bc3a7b6abad017c556dadd92c44701562cd528ac7fde4d5b", size = 470628, upload-time = "2026-06-12T08:04:50.506Z" },
-]
-
-[[package]]
 name = "docker"
 version = "6.1.3"
 source = { registry = "https://pypi.org/simple" }
@@ -473,15 +442,6 @@ wheels = [
 ]
 
 [[package]]
-name = "filelock"
-version = "3.19.1"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/40/bb/0ab3e58d22305b6f5440629d20683af28959bf793d98d11950e305c1c326/filelock-3.19.1.tar.gz", hash = "sha256:66eda1888b0171c998b35be2bcc0f6d75c388a7ce20c3f3f37aa8e96c2dddf58", size = 17687, upload-time = "2025-08-14T16:56:03.016Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/42/14/42b2651a2f46b022ccd948bca9f2d5af0fd8929c4eec235b8d6d844fbe67/filelock-3.19.1-py3-none-any.whl", hash = "sha256:d38e30481def20772f5baf097c122c3babc4fcdb7e14e57049eb9d88c6dc017d", size = 15988, upload-time = "2025-08-14T16:56:01.633Z" },
-]
-
-[[package]]
 name = "flaml"
 version = "1.0.14"
 source = { registry = "https://pypi.org/simple" }
@@ -532,31 +492,6 @@ wheels = [
 ]
 
 [[package]]
-name = "frozenlist"
-version = "1.8.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/2d/f5/c831fac6cc817d26fd54c7eaccd04ef7e0288806943f7cc5bbf69f3ac1f0/frozenlist-1.8.0.tar.gz", hash = "sha256:3ede829ed8d842f6cd48fc7081d7a41001a56f1f38603f9d49bf3020d59a31ad", size = 45875, upload-time = "2025-10-06T05:38:17.865Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/c2/59/ae5cdac87a00962122ea37bb346d41b66aec05f9ce328fa2b9e216f8967b/frozenlist-1.8.0-cp39-cp39-macosx_10_9_universal2.whl", hash = "sha256:d8b7138e5cd0647e4523d6685b0eac5d4be9a184ae9634492f25c6eb38c12a47", size = 86967, upload-time = "2025-10-06T05:37:55.607Z" },
-    { url = "https://files.pythonhosted.org/packages/8a/10/17059b2db5a032fd9323c41c39e9d1f5f9d0c8f04d1e4e3e788573086e61/frozenlist-1.8.0-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:a6483e309ca809f1efd154b4d37dc6d9f61037d6c6a81c2dc7a15cb22c8c5dca", size = 49984, upload-time = "2025-10-06T05:37:57.049Z" },
-    { url = "https://files.pythonhosted.org/packages/4b/de/ad9d82ca8e5fa8f0c636e64606553c79e2b859ad253030b62a21fe9986f5/frozenlist-1.8.0-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:1b9290cf81e95e93fdf90548ce9d3c1211cf574b8e3f4b3b7cb0537cf2227068", size = 50240, upload-time = "2025-10-06T05:37:58.145Z" },
-    { url = "https://files.pythonhosted.org/packages/4e/45/3dfb7767c2a67d123650122b62ce13c731b6c745bc14424eea67678b508c/frozenlist-1.8.0-cp39-cp39-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:59a6a5876ca59d1b63af8cd5e7ffffb024c3dc1e9cf9301b21a2e76286505c95", size = 219472, upload-time = "2025-10-06T05:37:59.239Z" },
-    { url = "https://files.pythonhosted.org/packages/0b/bf/5bf23d913a741b960d5c1dac7c1985d8a2a1d015772b2d18ea168b08e7ff/frozenlist-1.8.0-cp39-cp39-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:6dc4126390929823e2d2d9dc79ab4046ed74680360fc5f38b585c12c66cdf459", size = 221531, upload-time = "2025-10-06T05:38:00.521Z" },
-    { url = "https://files.pythonhosted.org/packages/d0/03/27ec393f3b55860859f4b74cdc8c2a4af3dbf3533305e8eacf48a4fd9a54/frozenlist-1.8.0-cp39-cp39-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:332db6b2563333c5671fecacd085141b5800cb866be16d5e3eb15a2086476675", size = 219211, upload-time = "2025-10-06T05:38:01.842Z" },
-    { url = "https://files.pythonhosted.org/packages/3a/ad/0fd00c404fa73fe9b169429e9a972d5ed807973c40ab6b3cf9365a33d360/frozenlist-1.8.0-cp39-cp39-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:9ff15928d62a0b80bb875655c39bf517938c7d589554cbd2669be42d97c2cb61", size = 231775, upload-time = "2025-10-06T05:38:03.384Z" },
-    { url = "https://files.pythonhosted.org/packages/8a/c3/86962566154cb4d2995358bc8331bfc4ea19d07db1a96f64935a1607f2b6/frozenlist-1.8.0-cp39-cp39-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:7bf6cdf8e07c8151fba6fe85735441240ec7f619f935a5205953d58009aef8c6", size = 236631, upload-time = "2025-10-06T05:38:04.609Z" },
-    { url = "https://files.pythonhosted.org/packages/ea/9e/6ffad161dbd83782d2c66dc4d378a9103b31770cb1e67febf43aea42d202/frozenlist-1.8.0-cp39-cp39-musllinux_1_2_aarch64.whl", hash = "sha256:48e6d3f4ec5c7273dfe83ff27c91083c6c9065af655dc2684d2c200c94308bb5", size = 218632, upload-time = "2025-10-06T05:38:05.917Z" },
-    { url = "https://files.pythonhosted.org/packages/58/b2/4677eee46e0a97f9b30735e6ad0bf6aba3e497986066eb68807ac85cf60f/frozenlist-1.8.0-cp39-cp39-musllinux_1_2_armv7l.whl", hash = "sha256:1a7607e17ad33361677adcd1443edf6f5da0ce5e5377b798fba20fae194825f3", size = 235967, upload-time = "2025-10-06T05:38:07.614Z" },
-    { url = "https://files.pythonhosted.org/packages/05/f3/86e75f8639c5a93745ca7addbbc9de6af56aebb930d233512b17e46f6493/frozenlist-1.8.0-cp39-cp39-musllinux_1_2_ppc64le.whl", hash = "sha256:5a3a935c3a4e89c733303a2d5a7c257ea44af3a56c8202df486b7f5de40f37e1", size = 228799, upload-time = "2025-10-06T05:38:08.845Z" },
-    { url = "https://files.pythonhosted.org/packages/30/00/39aad3a7f0d98f5eb1d99a3c311215674ed87061aecee7851974b335c050/frozenlist-1.8.0-cp39-cp39-musllinux_1_2_s390x.whl", hash = "sha256:940d4a017dbfed9daf46a3b086e1d2167e7012ee297fef9e1c545c4d022f5178", size = 230566, upload-time = "2025-10-06T05:38:10.52Z" },
-    { url = "https://files.pythonhosted.org/packages/0d/4d/aa144cac44568d137846ddc4d5210fb5d9719eb1d7ec6fa2728a54b5b94a/frozenlist-1.8.0-cp39-cp39-musllinux_1_2_x86_64.whl", hash = "sha256:b9be22a69a014bc47e78072d0ecae716f5eb56c15238acca0f43d6eb8e4a5bda", size = 217715, upload-time = "2025-10-06T05:38:11.832Z" },
-    { url = "https://files.pythonhosted.org/packages/64/4c/8f665921667509d25a0dd72540513bc86b356c95541686f6442a3283019f/frozenlist-1.8.0-cp39-cp39-win32.whl", hash = "sha256:1aa77cb5697069af47472e39612976ed05343ff2e84a3dcf15437b232cbfd087", size = 39933, upload-time = "2025-10-06T05:38:13.061Z" },
-    { url = "https://files.pythonhosted.org/packages/79/bd/bcc926f87027fad5e59926ff12d136e1082a115025d33c032d1cd69ab377/frozenlist-1.8.0-cp39-cp39-win_amd64.whl", hash = "sha256:7398c222d1d405e796970320036b1b563892b65809d9e5261487bb2c7f7b5c6a", size = 44121, upload-time = "2025-10-06T05:38:14.572Z" },
-    { url = "https://files.pythonhosted.org/packages/4c/07/9c2e4eb7584af4b705237b971b89a4155a8e57599c4483a131a39256a9a0/frozenlist-1.8.0-cp39-cp39-win_arm64.whl", hash = "sha256:b4f3b365f31c6cd4af24545ca0a244a53688cad8834e32f56831c4923b50a103", size = 40312, upload-time = "2025-10-06T05:38:15.699Z" },
-    { url = "https://files.pythonhosted.org/packages/9a/9a/e35b4a917281c0b8419d4207f4334c8e8c5dbf4f3f5f9ada73958d937dcc/frozenlist-1.8.0-py3-none-any.whl", hash = "sha256:0c18a16eab41e82c295618a77502e17b195883241c563b00f0aa5106fc4eaa0d", size = 13409, upload-time = "2025-10-06T05:38:16.721Z" },
-]
-
-[[package]]
 name = "geochemistrypi"
 version = "0.8.1"
 source = { editable = "." }
@@ -582,7 +517,6 @@ dependencies = [
     { name = "python-dotenv" },
     { name = "python-jose", extra = ["cryptography"] },
     { name = "python-multipart" },
-    { name = "ray", extra = ["tune"] },
     { name = "rich" },
     { name = "scikit-learn" },
     { name = "scipy" },
@@ -625,8 +559,6 @@ requires-dist = [
     { name = "python-dotenv", specifier = "==1.0.0" },
     { name = "python-jose", extras = ["cryptography"] },
     { name = "python-multipart", specifier = "==0.0.6" },
-    { name = "ray", specifier = "==2.2.0" },
-    { name = "ray", extras = ["tune"] },
     { name = "rich", specifier = "==13.3.5" },
     { name = "scikit-learn", specifier = "==1.1.3" },
     { name = "scipy", specifier = "==1.10.1" },
@@ -682,27 +614,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/c0/8b/9b3b85a89c22f55f315908b94cd75ab5fed5973f7393bbef000ca8b2c5c1/greenlet-3.1.1-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:d0028e725ee18175c6e422797c407874da24381ce0690d6b9396c204c7f7276e", size = 1147458, upload-time = "2024-09-20T17:09:33.708Z" },
     { url = "https://files.pythonhosted.org/packages/b8/1c/248fadcecd1790b0ba793ff81fa2375c9ad6442f4c748bf2cc2e6563346a/greenlet-3.1.1-cp39-cp39-win32.whl", hash = "sha256:5e06afd14cbaf9e00899fae69b24a32f2196c19de08fcb9f4779dd4f004e5e7c", size = 281131, upload-time = "2024-09-20T17:44:53.141Z" },
     { url = "https://files.pythonhosted.org/packages/ae/02/e7d0aef2354a38709b764df50b2b83608f0621493e47f47694eb80922822/greenlet-3.1.1-cp39-cp39-win_amd64.whl", hash = "sha256:3319aa75e0e0639bc15ff54ca327e8dc7a6fe404003496e3c6925cd3142e0e22", size = 298306, upload-time = "2024-09-20T17:33:23.059Z" },
-]
-
-[[package]]
-name = "grpcio"
-version = "1.80.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "typing-extensions" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/b7/48/af6173dbca4454f4637a4678b67f52ca7e0c1ed7d5894d89d434fecede05/grpcio-1.80.0.tar.gz", hash = "sha256:29aca15edd0688c22ba01d7cc01cb000d72b2033f4a3c72a81a19b56fd143257", size = 12978905, upload-time = "2026-03-30T08:49:10.502Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/08/58/7151ffa07cb3faf4bdd1a1902c067d2d162a4ba24678afd2ad5084a42382/grpcio-1.80.0-cp39-cp39-linux_armv7l.whl", hash = "sha256:aacdfb4ed3eb919ca997504d27e03d5dba403c85130b8ed450308590a738f7a4", size = 6048562, upload-time = "2026-03-30T08:48:40.068Z" },
-    { url = "https://files.pythonhosted.org/packages/40/58/0287051dc65c2760155977d9775d1f3c87939e4d575a29aac40f9006b357/grpcio-1.80.0-cp39-cp39-macosx_11_0_universal2.whl", hash = "sha256:a361c20ec1ccd3c3953d20fb6d7b4125093bdd10dff44c5e2bbb39e58917cedc", size = 12031536, upload-time = "2026-03-30T08:48:43.031Z" },
-    { url = "https://files.pythonhosted.org/packages/7b/62/8fc355ffcc9fd8a3ca0438f007307c130dfb93949d3138cd23c8c9f434e8/grpcio-1.80.0-cp39-cp39-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:43168871f170d1e4ed16ae03d10cd21efa29f190e710a624cee7e5ae07da6f4f", size = 6602175, upload-time = "2026-03-30T08:48:46.099Z" },
-    { url = "https://files.pythonhosted.org/packages/12/cb/3efd0b505090804dfe88bf258ed26a6fb19ccbb31889a05b9edb3ae035fe/grpcio-1.80.0-cp39-cp39-manylinux2014_i686.manylinux_2_17_i686.whl", hash = "sha256:1b97cd29a8eda100b559b455331c487a80915b6ea6bd91cf3e89836c4ee8d957", size = 7299777, upload-time = "2026-03-30T08:48:48.848Z" },
-    { url = "https://files.pythonhosted.org/packages/54/b1/50fdb826acafd5ac661e10df25b089721172530f2eb4aa1f36bd3c3d4254/grpcio-1.80.0-cp39-cp39-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:bac1d573dfa84ce59a5547073e28fa7326d53352adda6912e362da0b917fcef4", size = 6808790, upload-time = "2026-03-30T08:48:51.625Z" },
-    { url = "https://files.pythonhosted.org/packages/60/29/41e9ed0bb5544836bb2685097beea972b0cabc8970aeaace0f152bfc5441/grpcio-1.80.0-cp39-cp39-musllinux_1_2_aarch64.whl", hash = "sha256:4560cf0e86514595dbbd330cd65b7afad4b5c4b8c4905c041cfffa138d45e6fd", size = 7410605, upload-time = "2026-03-30T08:48:54.466Z" },
-    { url = "https://files.pythonhosted.org/packages/41/ad/889f0dfbc8a08050db6e23c3180dbe712b03af490352a4d7df649db26bc8/grpcio-1.80.0-cp39-cp39-musllinux_1_2_i686.whl", hash = "sha256:ec0a592e926071b4abad50c1495cd0d0d513324b3ff5e7267067c33ba27506e4", size = 8423134, upload-time = "2026-03-30T08:48:57.71Z" },
-    { url = "https://files.pythonhosted.org/packages/3d/76/f44d853f38165d26a309565da31a312587dda668e9e7b5323179b87bcab4/grpcio-1.80.0-cp39-cp39-musllinux_1_2_x86_64.whl", hash = "sha256:deb10a1528473c11f72a0939eed36d83e847d7cbb63e8cc5611fb7a912d38614", size = 7846917, upload-time = "2026-03-30T08:49:00.969Z" },
-    { url = "https://files.pythonhosted.org/packages/74/fe/99c56d12b48f8c8b0d28c42edfb171642eb52dd90a0fe7bc74676909fa97/grpcio-1.80.0-cp39-cp39-win32.whl", hash = "sha256:627fb7312171cdc52828bd6fac8d7028ff2a64b89f1957b6f3416caa2218d141", size = 4157647, upload-time = "2026-03-30T08:49:04.196Z" },
-    { url = "https://files.pythonhosted.org/packages/e6/ff/33f6a8823f06c6a1d1f530c1531e563b76c02091525e36255c08575ae775/grpcio-1.80.0-cp39-cp39-win_amd64.whl", hash = "sha256:05d55e1798756282cddd52d56c896b3e7d673e3a8798c2f1cd05ba249a3bb4de", size = 4892359, upload-time = "2026-03-30T08:49:06.902Z" },
 ]
 
 [[package]]
@@ -812,33 +723,6 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/45/dd/a5435a6902d6315241c48a5343e6e6675b007e05d3738ed97a7a47864e53/joblib-1.2.0.tar.gz", hash = "sha256:e1cee4a79e4af22881164f218d4311f60074197fb707e082e803b61f6d137018", size = 313200, upload-time = "2022-09-16T10:01:07.743Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/91/d4/3b4c8e5a30604df4c7518c562d4bf0502f2fa29221459226e140cf846512/joblib-1.2.0-py3-none-any.whl", hash = "sha256:091138ed78f800342968c523bdde947e7a305b8594b910a0fea2ab83c3c6d385", size = 297969, upload-time = "2022-09-16T10:01:04.791Z" },
-]
-
-[[package]]
-name = "jsonschema"
-version = "4.25.1"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "attrs" },
-    { name = "jsonschema-specifications" },
-    { name = "referencing" },
-    { name = "rpds-py" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/74/69/f7185de793a29082a9f3c7728268ffb31cb5095131a9c139a74078e27336/jsonschema-4.25.1.tar.gz", hash = "sha256:e4a9655ce0da0c0b67a085847e00a3a51449e1157f4f75e9fb5aa545e122eb85", size = 357342, upload-time = "2025-08-18T17:03:50.038Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/bf/9c/8c95d856233c1f82500c2450b8c68576b4cf1c871db3afac5c34ff84e6fd/jsonschema-4.25.1-py3-none-any.whl", hash = "sha256:3fba0169e345c7175110351d456342c364814cfcf3b964ba4587f22915230a63", size = 90040, upload-time = "2025-08-18T17:03:48.373Z" },
-]
-
-[[package]]
-name = "jsonschema-specifications"
-version = "2025.9.1"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "referencing" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/19/74/a633ee74eb36c44aa6d1095e7cc5569bebf04342ee146178e2d36600708b/jsonschema_specifications-2025.9.1.tar.gz", hash = "sha256:b540987f239e745613c7a9176f3edb72b832a4ac465cf02712288397832b5e8d", size = 32855, upload-time = "2025-09-08T01:34:59.186Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/41/45/1a4ed80516f02155c51f51e8cedb3c1902296743db0bbc66608a0db2814f/jsonschema_specifications-2025.9.1-py3-none-any.whl", hash = "sha256:98802fee3a11ee76ecaca44429fda8a41bff98b00a0f2838151b113f210cc6fe", size = 18437, upload-time = "2025-09-08T01:34:57.871Z" },
 ]
 
 [[package]]
@@ -1017,22 +901,6 @@ wheels = [
 ]
 
 [[package]]
-name = "msgpack"
-version = "1.1.2"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/4d/f2/bfb55a6236ed8725a96b0aa3acbd0ec17588e6a2c3b62a93eb513ed8783f/msgpack-1.1.2.tar.gz", hash = "sha256:3b60763c1373dd60f398488069bcdc703cd08a711477b5d480eecc9f9626f47e", size = 173581, upload-time = "2025-10-08T09:15:56.596Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/46/73/85469b4aa71d25e5949fee50d3c2cf46f69cea619fe97cfe309058080f75/msgpack-1.1.2-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:ea5405c46e690122a76531ab97a079e184c0daf491e588592d6a23d3e32af99e", size = 81529, upload-time = "2025-10-08T09:15:46.069Z" },
-    { url = "https://files.pythonhosted.org/packages/6c/3a/7d4077e8ae720b29d2b299a9591969f0d105146960681ea6f4121e6d0f8d/msgpack-1.1.2-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:9fba231af7a933400238cb357ecccf8ab5d51535ea95d94fc35b7806218ff844", size = 84106, upload-time = "2025-10-08T09:15:47.064Z" },
-    { url = "https://files.pythonhosted.org/packages/df/c0/da451c74746ed9388dca1b4ec647c82945f4e2f8ce242c25fb7c0e12181f/msgpack-1.1.2-cp39-cp39-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:a8f6e7d30253714751aa0b0c84ae28948e852ee7fb0524082e6716769124bc23", size = 396656, upload-time = "2025-10-08T09:15:48.118Z" },
-    { url = "https://files.pythonhosted.org/packages/e5/a1/20486c29a31ec9f0f88377fdf7eb7a67f30bcb5e0f89b7550f6f16d9373b/msgpack-1.1.2-cp39-cp39-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:94fd7dc7d8cb0a54432f296f2246bc39474e017204ca6f4ff345941d4ed285a7", size = 404722, upload-time = "2025-10-08T09:15:49.328Z" },
-    { url = "https://files.pythonhosted.org/packages/ad/ae/e613b0a526d54ce85447d9665c2ff8c3210a784378d50573321d43d324b8/msgpack-1.1.2-cp39-cp39-musllinux_1_2_aarch64.whl", hash = "sha256:350ad5353a467d9e3b126d8d1b90fe05ad081e2e1cef5753f8c345217c37e7b8", size = 391838, upload-time = "2025-10-08T09:15:50.517Z" },
-    { url = "https://files.pythonhosted.org/packages/49/6a/07f3e10ed4503045b882ef7bf8512d01d8a9e25056950a977bd5f50df1c2/msgpack-1.1.2-cp39-cp39-musllinux_1_2_x86_64.whl", hash = "sha256:6bde749afe671dc44893f8d08e83bf475a1a14570d67c4bb5cec5573463c8833", size = 397516, upload-time = "2025-10-08T09:15:51.646Z" },
-    { url = "https://files.pythonhosted.org/packages/76/9b/a86828e75986c12a3809c1e5062f5eba8e0cae3dfa2bf724ed2b1bb72b4c/msgpack-1.1.2-cp39-cp39-win32.whl", hash = "sha256:ad09b984828d6b7bb52d1d1d0c9be68ad781fa004ca39216c8a1e63c0f34ba3c", size = 64863, upload-time = "2025-10-08T09:15:53.118Z" },
-    { url = "https://files.pythonhosted.org/packages/14/a7/b1992b4fb3da3b413f5fb78a63bad42f256c3be2352eb69273c3789c2c96/msgpack-1.1.2-cp39-cp39-win_amd64.whl", hash = "sha256:67016ae8c8965124fdede9d3769528ad8284f14d635337ffa6a713a580f6c030", size = 71540, upload-time = "2025-10-08T09:15:55.573Z" },
-]
-
-[[package]]
 name = "multipledispatch"
 version = "0.6.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1174,15 +1042,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/64/79/6d4f638b288300bed727ff29f2a3cb63db054b33518a95f27724915e3fbc/pillow-11.3.0-cp39-cp39-win32.whl", hash = "sha256:ea944117a7974ae78059fcc1800e5d3295172bb97035c0c1d9345fca1419da71", size = 6277091, upload-time = "2025-07-01T09:16:04.4Z" },
     { url = "https://files.pythonhosted.org/packages/46/05/4106422f45a05716fd34ed21763f8ec182e8ea00af6e9cb05b93a247361a/pillow-11.3.0-cp39-cp39-win_amd64.whl", hash = "sha256:e5c5858ad8ec655450a7c7df532e9842cf8df7cc349df7225c60d5d348c8aada", size = 6986091, upload-time = "2025-07-01T09:16:06.342Z" },
     { url = "https://files.pythonhosted.org/packages/63/c6/287fd55c2c12761d0591549d48885187579b7c257bef0c6660755b0b59ae/pillow-11.3.0-cp39-cp39-win_arm64.whl", hash = "sha256:6abdbfd3aea42be05702a8dd98832329c167ee84400a1d1f61ab11437f1717eb", size = 2422632, upload-time = "2025-07-01T09:16:08.142Z" },
-]
-
-[[package]]
-name = "platformdirs"
-version = "4.4.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/23/e8/21db9c9987b0e728855bd57bff6984f67952bea55d6f75e055c46b5383e8/platformdirs-4.4.0.tar.gz", hash = "sha256:ca753cf4d81dc309bc67b0ea38fd15dc97bc30ce419a7f58d13eb3bf14c4febf", size = 21634, upload-time = "2025-08-26T14:32:04.268Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/40/4b/2028861e724d3bd36227adfa20d3fd24c3fc6d52032f4a93c133be5d17ce/platformdirs-4.4.0-py3-none-any.whl", hash = "sha256:abd01743f24e5287cd7a5db3752faf1a2d65353f38ec26d98e25a6db65958c85", size = 18654, upload-time = "2025-08-26T14:32:02.735Z" },
 ]
 
 [[package]]
@@ -1363,18 +1222,6 @@ wheels = [
 ]
 
 [[package]]
-name = "python-discovery"
-version = "1.5.1"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "filelock" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/04/b7/1581a8103855c43567776aa34135e5ec3c597346c23bfd10c7eb5e0b10a4/python_discovery-1.5.1.tar.gz", hash = "sha256:e2ea8b884cd1701f386eda8cf327b87743f1dc21b7f784470799537d95635384", size = 77200, upload-time = "2026-07-31T22:06:02.48Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/6a/07/a89b539750a159d5101c4eb9fc84e2961f65cefbd5e0b7440b284471c0b0/python_discovery-1.5.1-py3-none-any.whl", hash = "sha256:ac07f44cade589d954e9d6a1e1468539fdddd2cf676beb51da73e0f156b7c932", size = 35752, upload-time = "2026-07-31T22:06:01.116Z" },
-]
-
-[[package]]
 name = "python-dotenv"
 version = "1.0.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1461,55 +1308,6 @@ wheels = [
 ]
 
 [[package]]
-name = "ray"
-version = "2.2.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "aiosignal" },
-    { name = "attrs" },
-    { name = "click" },
-    { name = "filelock" },
-    { name = "frozenlist" },
-    { name = "grpcio" },
-    { name = "jsonschema" },
-    { name = "msgpack" },
-    { name = "numpy" },
-    { name = "protobuf" },
-    { name = "pyyaml" },
-    { name = "requests" },
-    { name = "virtualenv" },
-]
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/e9/1b/1bf042006a16fb2c3e35341c3a0d9c017390d73605b8c56c652446d89a84/ray-2.2.0-cp39-cp39-macosx_10_15_x86_64.whl", hash = "sha256:9c54e71524da5745fecfb8f2618d9e414611374306111c6168225d45f751c842", size = 76624443, upload-time = "2022-12-13T19:57:58.13Z" },
-    { url = "https://files.pythonhosted.org/packages/12/84/e8aed9639adc020e10cce5ec290baca9c2333da6d59f94b31d0bd07b5983/ray-2.2.0-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:4961b2572ee3f441acadf5d8c129d56c246dd2f71bbe0082c16e3ecd47d5df08", size = 27443233, upload-time = "2022-12-13T19:58:05.406Z" },
-    { url = "https://files.pythonhosted.org/packages/cd/b5/7a5fa3697cb71856c69f1271f20a9848455a8cd17c1f2c0d5b625db7251a/ray-2.2.0-cp39-cp39-manylinux2014_aarch64.whl", hash = "sha256:d8baeb71d3e3c5d621dd12e71db29989832dcc58b2c2037be1637d7a6ce60109", size = 55901494, upload-time = "2023-01-10T20:55:46.338Z" },
-    { url = "https://files.pythonhosted.org/packages/ee/85/bf8841245fb1869352a901c9eb1ebe341c23a35b3df17ab0e94dc0d218c2/ray-2.2.0-cp39-cp39-manylinux2014_x86_64.whl", hash = "sha256:141885d72242e4a782cc1c9e22c7a5466c6287c3cc7564f04377de10bf774d53", size = 57380341, upload-time = "2022-12-13T19:58:13.222Z" },
-    { url = "https://files.pythonhosted.org/packages/63/9a/96085b1c99d810d5af634fc591779a6985b8c07e889805641c7c4a88cecd/ray-2.2.0-cp39-cp39-win_amd64.whl", hash = "sha256:23e46c18b33f2e0a10e7a62e14a4e07d6a22ac287dc357b09df2382edc4b3fd7", size = 20824406, upload-time = "2022-12-13T19:58:21.213Z" },
-]
-
-[package.optional-dependencies]
-tune = [
-    { name = "pandas" },
-    { name = "requests" },
-    { name = "tabulate" },
-    { name = "tensorboardx" },
-]
-
-[[package]]
-name = "referencing"
-version = "0.36.2"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "attrs" },
-    { name = "rpds-py" },
-    { name = "typing-extensions" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/2f/db/98b5c277be99dd18bfd91dd04e1b759cad18d1a338188c936e92f921c7e2/referencing-0.36.2.tar.gz", hash = "sha256:df2e89862cd09deabbdba16944cc3f10feb6b3e6f18e902f7cc25609a34775aa", size = 74744, upload-time = "2025-01-25T08:48:16.138Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/c1/b1/3baf80dc6d2b7bc27a95a67752d0208e410351e3feb4eb78de5f77454d8d/referencing-0.36.2-py3-none-any.whl", hash = "sha256:e8699adbbf8b5c7de96d8ffa0eb5c158b3beafce084968e2ea8bb08c6794dcd0", size = 26775, upload-time = "2025-01-25T08:48:14.241Z" },
-]
-
-[[package]]
 name = "requests"
 version = "2.32.5"
 source = { registry = "https://pypi.org/simple" }
@@ -1535,41 +1333,6 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/3d/0b/8dd34d20929c4b5e474db2e64426175469c2b7fea5ba71c6d4b3397a9729/rich-13.3.5.tar.gz", hash = "sha256:2d11b9b8dd03868f09b4fffadc84a6a8cda574e40dc90821bd845720ebb8e89c", size = 219245, upload-time = "2023-04-27T14:16:53.387Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/39/03/6de23bdd88f5ee7f8b03f94f6e88108f5d7ffe6d207e95cdb06d9aa4cd57/rich-13.3.5-py3-none-any.whl", hash = "sha256:69cdf53799e63f38b95b9bf9c875f8c90e78dd62b2f00c13a911c7a3b9fa4704", size = 238731, upload-time = "2023-04-27T14:16:51.41Z" },
-]
-
-[[package]]
-name = "rpds-py"
-version = "0.27.1"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/e9/dd/2c0cbe774744272b0ae725f44032c77bdcab6e8bcf544bffa3b6e70c8dba/rpds_py-0.27.1.tar.gz", hash = "sha256:26a1c73171d10b7acccbded82bf6a586ab8203601e565badc74bbbf8bc5a10f8", size = 27479, upload-time = "2025-08-27T12:16:36.024Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/7f/6c/252e83e1ce7583c81f26d1d884b2074d40a13977e1b6c9c50bbf9a7f1f5a/rpds_py-0.27.1-cp39-cp39-macosx_10_12_x86_64.whl", hash = "sha256:c918c65ec2e42c2a78d19f18c553d77319119bf43aa9e2edf7fb78d624355527", size = 372140, upload-time = "2025-08-27T12:15:05.441Z" },
-    { url = "https://files.pythonhosted.org/packages/9d/71/949c195d927c5aeb0d0629d329a20de43a64c423a6aa53836290609ef7ec/rpds_py-0.27.1-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:1fea2b1a922c47c51fd07d656324531adc787e415c8b116530a1d29c0516c62d", size = 354086, upload-time = "2025-08-27T12:15:07.404Z" },
-    { url = "https://files.pythonhosted.org/packages/9f/02/e43e332ad8ce4f6c4342d151a471a7f2900ed1d76901da62eb3762663a71/rpds_py-0.27.1-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:bbf94c58e8e0cd6b6f38d8de67acae41b3a515c26169366ab58bdca4a6883bb8", size = 382117, upload-time = "2025-08-27T12:15:09.275Z" },
-    { url = "https://files.pythonhosted.org/packages/d0/05/b0fdeb5b577197ad72812bbdfb72f9a08fa1e64539cc3940b1b781cd3596/rpds_py-0.27.1-cp39-cp39-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:c2a8fed130ce946d5c585eddc7c8eeef0051f58ac80a8ee43bd17835c144c2cc", size = 394520, upload-time = "2025-08-27T12:15:10.727Z" },
-    { url = "https://files.pythonhosted.org/packages/67/1f/4cfef98b2349a7585181e99294fa2a13f0af06902048a5d70f431a66d0b9/rpds_py-0.27.1-cp39-cp39-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:037a2361db72ee98d829bc2c5b7cc55598ae0a5e0ec1823a56ea99374cfd73c1", size = 522657, upload-time = "2025-08-27T12:15:12.613Z" },
-    { url = "https://files.pythonhosted.org/packages/44/55/ccf37ddc4c6dce7437b335088b5ca18da864b334890e2fe9aa6ddc3f79a9/rpds_py-0.27.1-cp39-cp39-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:5281ed1cc1d49882f9997981c88df1a22e140ab41df19071222f7e5fc4e72125", size = 402967, upload-time = "2025-08-27T12:15:14.113Z" },
-    { url = "https://files.pythonhosted.org/packages/74/e5/5903f92e41e293b07707d5bf00ef39a0eb2af7190aff4beaf581a6591510/rpds_py-0.27.1-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:2fd50659a069c15eef8aa3d64bbef0d69fd27bb4a50c9ab4f17f83a16cbf8905", size = 384372, upload-time = "2025-08-27T12:15:15.842Z" },
-    { url = "https://files.pythonhosted.org/packages/8f/e3/fbb409e18aeefc01e49f5922ac63d2d914328430e295c12183ce56ebf76b/rpds_py-0.27.1-cp39-cp39-manylinux_2_31_riscv64.whl", hash = "sha256:c4b676c4ae3921649a15d28ed10025548e9b561ded473aa413af749503c6737e", size = 401264, upload-time = "2025-08-27T12:15:17.388Z" },
-    { url = "https://files.pythonhosted.org/packages/55/79/529ad07794e05cb0f38e2f965fc5bb20853d523976719400acecc447ec9d/rpds_py-0.27.1-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:079bc583a26db831a985c5257797b2b5d3affb0386e7ff886256762f82113b5e", size = 418691, upload-time = "2025-08-27T12:15:19.144Z" },
-    { url = "https://files.pythonhosted.org/packages/33/39/6554a7fd6d9906fda2521c6d52f5d723dca123529fb719a5b5e074c15e01/rpds_py-0.27.1-cp39-cp39-musllinux_1_2_aarch64.whl", hash = "sha256:4e44099bd522cba71a2c6b97f68e19f40e7d85399de899d66cdb67b32d7cb786", size = 558989, upload-time = "2025-08-27T12:15:21.087Z" },
-    { url = "https://files.pythonhosted.org/packages/19/b2/76fa15173b6f9f445e5ef15120871b945fb8dd9044b6b8c7abe87e938416/rpds_py-0.27.1-cp39-cp39-musllinux_1_2_i686.whl", hash = "sha256:e202e6d4188e53c6661af813b46c37ca2c45e497fc558bacc1a7630ec2695aec", size = 589835, upload-time = "2025-08-27T12:15:22.696Z" },
-    { url = "https://files.pythonhosted.org/packages/ee/9e/5560a4b39bab780405bed8a88ee85b30178061d189558a86003548dea045/rpds_py-0.27.1-cp39-cp39-musllinux_1_2_x86_64.whl", hash = "sha256:f41f814b8eaa48768d1bb551591f6ba45f87ac76899453e8ccd41dba1289b04b", size = 555227, upload-time = "2025-08-27T12:15:24.278Z" },
-    { url = "https://files.pythonhosted.org/packages/52/d7/cd9c36215111aa65724c132bf709c6f35175973e90b32115dedc4ced09cb/rpds_py-0.27.1-cp39-cp39-win32.whl", hash = "sha256:9e71f5a087ead99563c11fdaceee83ee982fd39cf67601f4fd66cb386336ee52", size = 217899, upload-time = "2025-08-27T12:15:25.926Z" },
-    { url = "https://files.pythonhosted.org/packages/5b/e0/d75ab7b4dd8ba777f6b365adbdfc7614bbfe7c5f05703031dfa4b61c3d6c/rpds_py-0.27.1-cp39-cp39-win_amd64.whl", hash = "sha256:71108900c9c3c8590697244b9519017a400d9ba26a36c48381b3f64743a44aab", size = 228725, upload-time = "2025-08-27T12:15:27.398Z" },
-    { url = "https://files.pythonhosted.org/packages/4e/ea/5463cd5048a7a2fcdae308b6e96432802132c141bfb9420260142632a0f1/rpds_py-0.27.1-pp39-pypy39_pp73-macosx_10_12_x86_64.whl", hash = "sha256:aa8933159edc50be265ed22b401125c9eebff3171f570258854dbce3ecd55475", size = 371778, upload-time = "2025-08-27T12:16:13.851Z" },
-    { url = "https://files.pythonhosted.org/packages/0d/c8/f38c099db07f5114029c1467649d308543906933eebbc226d4527a5f4693/rpds_py-0.27.1-pp39-pypy39_pp73-macosx_11_0_arm64.whl", hash = "sha256:a50431bf02583e21bf273c71b89d710e7a710ad5e39c725b14e685610555926f", size = 354394, upload-time = "2025-08-27T12:16:15.609Z" },
-    { url = "https://files.pythonhosted.org/packages/7d/79/b76f97704d9dd8ddbd76fed4c4048153a847c5d6003afe20a6b5c3339065/rpds_py-0.27.1-pp39-pypy39_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:78af06ddc7fe5cc0e967085a9115accee665fb912c22a3f54bad70cc65b05fe6", size = 382348, upload-time = "2025-08-27T12:16:17.251Z" },
-    { url = "https://files.pythonhosted.org/packages/8a/3f/ef23d3c1be1b837b648a3016d5bbe7cfe711422ad110b4081c0a90ef5a53/rpds_py-0.27.1-pp39-pypy39_pp73-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:70d0738ef8fee13c003b100c2fbd667ec4f133468109b3472d249231108283a3", size = 394159, upload-time = "2025-08-27T12:16:19.251Z" },
-    { url = "https://files.pythonhosted.org/packages/74/8a/9e62693af1a34fd28b1a190d463d12407bd7cf561748cb4745845d9548d3/rpds_py-0.27.1-pp39-pypy39_pp73-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:e2f6fd8a1cea5bbe599b6e78a6e5ee08db434fc8ffea51ff201c8765679698b3", size = 522775, upload-time = "2025-08-27T12:16:20.929Z" },
-    { url = "https://files.pythonhosted.org/packages/36/0d/8d5bb122bf7a60976b54c5c99a739a3819f49f02d69df3ea2ca2aff47d5c/rpds_py-0.27.1-pp39-pypy39_pp73-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:8177002868d1426305bb5de1e138161c2ec9eb2d939be38291d7c431c4712df8", size = 402633, upload-time = "2025-08-27T12:16:22.548Z" },
-    { url = "https://files.pythonhosted.org/packages/0f/0e/237948c1f425e23e0cf5a566d702652a6e55c6f8fbd332a1792eb7043daf/rpds_py-0.27.1-pp39-pypy39_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:008b839781d6c9bf3b6a8984d1d8e56f0ec46dc56df61fd669c49b58ae800400", size = 384867, upload-time = "2025-08-27T12:16:24.29Z" },
-    { url = "https://files.pythonhosted.org/packages/d6/0a/da0813efcd998d260cbe876d97f55b0f469ada8ba9cbc47490a132554540/rpds_py-0.27.1-pp39-pypy39_pp73-manylinux_2_31_riscv64.whl", hash = "sha256:a55b9132bb1ade6c734ddd2759c8dc132aa63687d259e725221f106b83a0e485", size = 401791, upload-time = "2025-08-27T12:16:25.954Z" },
-    { url = "https://files.pythonhosted.org/packages/51/78/c6c9e8a8aaca416a6f0d1b6b4a6ee35b88fe2c5401d02235d0a056eceed2/rpds_py-0.27.1-pp39-pypy39_pp73-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:a46fdec0083a26415f11d5f236b79fa1291c32aaa4a17684d82f7017a1f818b1", size = 419525, upload-time = "2025-08-27T12:16:27.659Z" },
-    { url = "https://files.pythonhosted.org/packages/a3/69/5af37e1d71487cf6d56dd1420dc7e0c2732c1b6ff612aa7a88374061c0a8/rpds_py-0.27.1-pp39-pypy39_pp73-musllinux_1_2_aarch64.whl", hash = "sha256:8a63b640a7845f2bdd232eb0d0a4a2dd939bcdd6c57e6bb134526487f3160ec5", size = 559255, upload-time = "2025-08-27T12:16:29.343Z" },
-    { url = "https://files.pythonhosted.org/packages/40/7f/8b7b136069ef7ac3960eda25d832639bdb163018a34c960ed042dd1707c8/rpds_py-0.27.1-pp39-pypy39_pp73-musllinux_1_2_i686.whl", hash = "sha256:7e32721e5d4922deaaf963469d795d5bde6093207c52fec719bd22e5d1bedbc4", size = 590384, upload-time = "2025-08-27T12:16:31.005Z" },
-    { url = "https://files.pythonhosted.org/packages/d8/06/c316d3f6ff03f43ccb0eba7de61376f8ec4ea850067dddfafe98274ae13c/rpds_py-0.27.1-pp39-pypy39_pp73-musllinux_1_2_x86_64.whl", hash = "sha256:2c426b99a068601b5f4623573df7a7c3d72e87533a2dd2253353a03e7502566c", size = 555959, upload-time = "2025-08-27T12:16:32.73Z" },
-    { url = "https://files.pythonhosted.org/packages/60/94/384cf54c430b9dac742bbd2ec26c23feb78ded0d43d6d78563a281aec017/rpds_py-0.27.1-pp39-pypy39_pp73-win_amd64.whl", hash = "sha256:4fc9b7fe29478824361ead6e14e4f5aed570d477e06088826537e202d25fe859", size = 228784, upload-time = "2025-08-27T12:16:34.428Z" },
 ]
 
 [[package]]
@@ -1748,20 +1511,6 @@ wheels = [
 ]
 
 [[package]]
-name = "tensorboardx"
-version = "2.6.5"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "numpy" },
-    { name = "packaging" },
-    { name = "protobuf" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/48/a9/fc520ea91ab1f3ba51cbf3fe24f2b6364ed3b49046969e0868d46d6da372/tensorboardx-2.6.5.tar.gz", hash = "sha256:ca176db3997ee8c07d2eb77381225956a3fd1c10c91beafab1f17069adc47017", size = 4770195, upload-time = "2026-04-03T15:40:23.803Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/87/0f/69fbab4c30b2f3a76e6de67585ea72a8eccf381751f5c0046b966fde9658/tensorboardx-2.6.5-py3-none-any.whl", hash = "sha256:c10b891d00af306537cb8b58a039b2ba41571f0da06f433a41c4ca8d6abe1373", size = 87510, upload-time = "2026-04-03T15:40:22.111Z" },
-]
-
-[[package]]
 name = "threadpoolctl"
 version = "3.1.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1832,22 +1581,6 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/c6/dd/0d3bab50ab4ef8bec849f89fec2adc2fabcc397018c30e57d9f0d4009c5e/uvicorn-0.22.0.tar.gz", hash = "sha256:79277ae03db57ce7d9aa0567830bbb51d7a612f54d6e1e3e92da3ef24c2c8ed8", size = 37688, upload-time = "2023-04-28T00:53:40.158Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/ad/bd/d47ee02312640fcf26c7e1c807402d5c5eab468571153a94ec8f7ada0e46/uvicorn-0.22.0-py3-none-any.whl", hash = "sha256:e9434d3bbf05f310e762147f769c9f21235ee118ba2d2bf1155a7196448bd996", size = 58345, upload-time = "2023-04-28T00:53:38.517Z" },
-]
-
-[[package]]
-name = "virtualenv"
-version = "21.7.1"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "distlib" },
-    { name = "filelock" },
-    { name = "platformdirs" },
-    { name = "python-discovery" },
-    { name = "typing-extensions" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/ea/fa/18004e5cb15541ad2a68ff219c755233b012b12d4ec8663d06a258082bec/virtualenv-21.7.1.tar.gz", hash = "sha256:d0dbfaa5483487baea28d7210ef8d24c9d1bd0f10f449eeb215568825a9b334e", size = 5525237, upload-time = "2026-07-30T15:40:36.36Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/4b/a7/ded126c19495158a05c7202b3389139839d4cf78d622d453867778e0f7a8/virtualenv-21.7.1-py3-none-any.whl", hash = "sha256:6394973f990536e34c05157179146c020284c42fe01da1dfeb0ba16c345280d9", size = 5504576, upload-time = "2026-07-30T15:40:34.512Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- make MCP setup, doctor, and release output safe for Unicode paths on Windows and improve CLI failure diagnostics
- replace Ray-backed MLP AutoML searches with deterministic in-process candidates to avoid worker hangs while preserving CLI/MCP parity
- validate one reusable release candidate across Windows, Ubuntu, and macOS, including installed-wheel lifecycle and classification/regression AutoML checks
- require both signed installation and signed parity gates before any PyPI or GitHub Release publication

## Testing
- local release preflight passed: formatting, wheel inspection, installed tests, CLI/MCP parity, manifest verification, and lifecycle checks
- targeted Unicode console regression test passed in isolated Python 3.11
- pre-commit run --all-files passed without modifying files
- Engine baseline run 31315403072 passed all 19 jobs on commit 6fa7a7f0

## Notes
- no tags were created, moved, or deleted
- this PR does not publish to PyPI or create a GitHub Release